### PR TITLE
Fix eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "axios": "^0.17.1",
+    "eslint": "^4.19.1",
     "faker": "^4.1.0",
     "lodash": "^4.17.4",
     "node-sass-chokidar": "^0.0.3",


### PR DESCRIPTION
Fix:
```
Failed to compile.
./src/index.js
Module build failed: Error: Cannot find module 'eslint/lib/formatters/stylish'
```

after 

> npm start